### PR TITLE
Improve typing for T2 payloads

### DIFF
--- a/ampel/types.py
+++ b/ampel/types.py
@@ -7,7 +7,7 @@
 # Last Modified Date:  31.12.2021
 # Last Modified By:    valery brinnel <firstname.lastname@gmail.com>
 
-from collections.abc import KeysView, Sequence, ValuesView
+from collections.abc import KeysView, Mapping, Sequence, ValuesView
 from typing import (  # type: ignore[attr-defined]
 	TYPE_CHECKING,
 	Annotated,
@@ -40,9 +40,9 @@ JDict = dict[str, Any] # JSON dict
 T2Link = Union[StockId, DataPointId, int]
 T3Send = Union['JournalAttributes', 'StockAttributes', tuple[StockId, 'StockAttributes']]
 
-UBson = Union[None, str, int, float, bool, bytes, list[Any], dict[str, Any]]
-TBson = TypeVar("TBson", str, int, float, bool, bytes, list, dict)
-ubson = (str, int, float, bool, bytes, list, dict)
+UBson = Union[None, str, int, float, bool, bytes, list[Any], Mapping[str, Any]]
+TBson = TypeVar("TBson", str, int, float, bool, bytes, list, Mapping)
+ubson = (str, int, float, bool, bytes, list, Mapping)
 StrictIterable = Union[list[T], set[T], tuple[T], frozenset[T], ValuesView[T], KeysView[T]]
 strict_iterable = (list, tuple, set, frozenset, ValuesView, KeysView)
 

--- a/ampel/view/SnapView.py
+++ b/ampel/view/SnapView.py
@@ -7,7 +7,7 @@
 # Last Modified Date:  24.11.2022
 # Last Modified By:    simeon reusch
 
-from collections.abc import Callable, Container, Iterator, Sequence
+from collections.abc import Callable, Container, Iterator, Mapping, Sequence
 from datetime import datetime, timezone
 from typing import Any, Literal, overload
 
@@ -18,7 +18,7 @@ from ampel.content.LogDocument import LogDocument
 from ampel.content.StockDocument import StockDocument
 from ampel.content.T1Document import T1Document
 from ampel.struct.AmpelBuffer import AmpelBuffer
-from ampel.types import OneOrMany, StockId, T, T2Link, UBson
+from ampel.types import OneOrMany, StockId, T2Link, TBson, UBson
 from ampel.util.freeze import recursive_freeze as rf
 from ampel.view.T2DocView import T2DocView
 
@@ -188,23 +188,23 @@ class SnapView:
 
 
 	@overload
-	def get_t2_body(self, unit: str | list[str] | tuple[str, ...]) -> None | dict[str, Any]:
+	def get_t2_body(self, unit: str | list[str] | tuple[str, ...]) -> None | Mapping[str, Any]:
 		...
 	@overload
-	def get_t2_body(self, unit: str | list[str] | tuple[str, ...], ret_type: type[T]) -> None | T:
+	def get_t2_body(self, unit: str | list[str] | tuple[str, ...], ret_type: type[TBson]) -> None | TBson:
 		...
 	@overload
-	def get_t2_body(self, unit: str | list[str] | tuple[str, ...], ret_type: type[T], *, raise_exc: Literal[True]) -> T:
+	def get_t2_body(self, unit: str | list[str] | tuple[str, ...], ret_type: type[TBson], *, raise_exc: Literal[True]) -> TBson:
 		...
 	def get_t2_body(self,
 		unit: str | list[str] | tuple[str, ...],
-		ret_type: type[T] = dict, # type: ignore[assignment]
+		ret_type: type[TBson] = Mapping[str, Any], # type: ignore[assignment]
 		*,
 		data_slice: int = -1, # latest
 		link: None | T2Link = None,
 		code: None | int = None,
 		raise_exc: bool = False
-	) -> None | T:
+	) -> None | TBson:
 		"""
 		Get latest t2 body element from a given unit.
 		:param ret_type: expected body element type. If isinstance check is not fullfied
@@ -223,9 +223,9 @@ class SnapView:
 	def get_t2_value(self,
 		unit: str | tuple[str, ...],
 		key: str,
-		rtype: type[T], *,
+		rtype: type[TBson], *,
 		code: None | int = None
-	) -> None | T:
+	) -> None | TBson:
 		"""
 		Examples:
 		get_t2_value(("T2NedSNCosmo", "T2SNCosmo"), "fit_result", dict)
@@ -240,26 +240,26 @@ class SnapView:
 
 	@overload
 	def get_t2_ntuple(self,
-		unit: str | tuple[str, ...], key: tuple[str, ...], rtype: type[T], *,
+		unit: str | tuple[str, ...], key: tuple[str, ...], rtype: type[TBson], *,
 		no_none: Literal[False], require_all_keys: bool = ..., code: None | int = ...
-	) -> None | tuple[None | T, ...]:
+	) -> None | tuple[None | TBson, ...]:
 		...
 
 	@overload
 	def get_t2_ntuple(self,
-		unit: str | tuple[str, ...], key: tuple[str, ...], rtype: type[T], *,
+		unit: str | tuple[str, ...], key: tuple[str, ...], rtype: type[TBson], *,
 		no_none: Literal[True], require_all_keys: bool = ..., code: None | int = ...
-	) -> None | tuple[T, ...]:
+	) -> None | tuple[TBson, ...]:
 		...
 
 	def get_t2_ntuple(self,
 		unit: str | tuple[str, ...],
 		key: tuple[str, ...],
-		rtype: type[T], *,
+		rtype: type[TBson], *,
 		no_none: bool = False,
 		require_all_keys: bool = True,
 		code: None | int = None
-	) -> None | tuple[T, ...] | tuple[None | T, ...]:
+	) -> None | tuple[TBson, ...] | tuple[None | TBson, ...]:
 		"""
 		Examples:
 		get_t2_ntuple("T2NedTap", ("ra", "dec", "z", "zunc"), float)

--- a/ampel/view/T2DocView.py
+++ b/ampel/view/T2DocView.py
@@ -131,18 +131,29 @@ class T2DocView:
 		...
 
 	@overload
+	def get_payload(self, *, raise_exc: Literal[True], code: None | int=None) -> Mapping[str, Any]:
+		...
+
+	@overload
 	def get_payload(self, rtype: type[TBson], *, code: None | int=None) -> None | TBson:
+		...
+	
+	@overload
+	def get_payload(self, rtype: type[TBson], *, raise_exc: Literal[True], code: None | int=None) ->  TBson:
 		...
 
 	def get_payload(self,
 		rtype: type[TBson]=Mapping,  # type: ignore[assignment]
 		*,
+		raise_exc: bool = False,
 		code: None | int = None,
 	) -> None | TBson | UBson:
 		"""
 		:returns: the content of the last array element of body associated with a meta code >= 0 or equals code arg.
 		"""
 		if not self.body:
+			if raise_exc:
+				raise ValueError("T2 doc has no body")
 			return None
 
 		idx = len(
@@ -154,12 +165,18 @@ class T2DocView:
 		) - 1
 
 		if idx == -1:
+			if raise_exc:
+				raise ValueError("No content available")
 			return None
 
 		# A manual/admin $unset: {body: 1} was used to delete bad data
 		idx = min(idx, len(self.body) - 1)
+		if idx < 0:
+			if raise_exc:
+				raise ValueError("No content available")
+			return None
 
-		return self.body[idx] if idx >= 0 else None
+		return self.body[idx]
 
 
 	def is_point_type(self) -> bool:

--- a/ampel/view/T2DocView.py
+++ b/ampel/view/T2DocView.py
@@ -7,14 +7,14 @@
 # Last Modified Date:  01.03.2023
 # Last Modified By:    valery brinnel <firstname.lastname@gmail.com>
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from typing import Any, Literal, overload
 
 from ampel.config.AmpelConfig import AmpelConfig
 from ampel.content.MetaRecord import MetaRecord
 from ampel.content.T2Document import T2Document
-from ampel.types import StockId, T, T2Link, Tag, UBson
+from ampel.types import StockId, T2Link, Tag, TBson, UBson
 
 TYPE_POINT_T2 = 0 # linked with datapoints (tier 0)
 TYPE_STATE_T2 = 1 # linked with compounds (tier 1)
@@ -126,7 +126,19 @@ class T2DocView:
 	def has_content(self) -> bool:
 		return bool(self.body)
 
-	def get_payload(self, code: None | int = None) -> UBson:
+	@overload
+	def get_payload(self, *, code: None | int=None) -> None | Mapping[str, Any]:
+		...
+
+	@overload
+	def get_payload(self, rtype: type[TBson], *, code: None | int=None) -> None | TBson:
+		...
+
+	def get_payload(self,
+		rtype: type[TBson]=Mapping,  # type: ignore[assignment]
+		*,
+		code: None | int = None,
+	) -> None | TBson | UBson:
 		"""
 		:returns: the content of the last array element of body associated with a meta code >= 0 or equals code arg.
 		"""
@@ -164,9 +176,9 @@ class T2DocView:
 
 	def get_value(self,
 		key: str,
-		rtype: type[T], *,
+		rtype: type[TBson], *,
 		code: None | int = None,
-	) -> None | T:
+	) -> None | TBson:
 		"""
 		:returns: the value of a given key from the content of the last array element of body
 		associated with a meta code >= 0 or equals code arg
@@ -174,33 +186,33 @@ class T2DocView:
 		Examples:
 		get_value("fit_result", dict)
 		"""
-		r = self.get_payload(code)
-		if isinstance(r, dict) and key in r:
+		r = self.get_payload(code=code)
+		if isinstance(r, Mapping) and key in r:
 			return r[key]
 		return None
 
 
 	@overload
 	def get_ntuple(self,
-		key: tuple[str, ...], rtype: type[T], *,
+		key: tuple[str, ...], rtype: type[TBson], *,
 		no_none: Literal[True], require_all_keys: bool, code: None | int
-	) -> None | tuple[T, ...]:
+	) -> None | tuple[TBson, ...]:
 		...
 
 	@overload
 	def get_ntuple(self,
-		key: tuple[str, ...], rtype: type[T], *,
+		key: tuple[str, ...], rtype: type[TBson], *,
 		no_none: Literal[False], require_all_keys: bool, code: None | int
-	) -> None | tuple[None | T, ...]:
+	) -> None | tuple[None | TBson, ...]:
 		...
 
 	def get_ntuple(self,
 		key: tuple[str, ...],
-		rtype: type[T], *,
+		rtype: type[TBson], *,
 		no_none: bool = False,
 		require_all_keys: bool = True,
 		code: None | int = None,
-	) -> None | tuple[T, ...] | tuple[None | T, ...]:
+	) -> None | tuple[TBson, ...] | tuple[None | TBson, ...]:
 		"""
 		Returns a tuple of n values from the content of the last array element of body
 		associated with a meta code >= 0 or equals code arg
@@ -230,7 +242,7 @@ class T2DocView:
 		Out[]: None
 		"""
 
-		r = self.get_payload(code)
+		r = self.get_payload(code=code)
 
 		if (
 			isinstance(r, dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-interface"
-version = "0.10.2"
+version = "0.10.3a0"
 description = "Base classes for the Ampel analysis platform"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,6 @@
 import pickle
 from collections.abc import Generator, Mapping
-from typing import no_type_check
+from typing import TypedDict, no_type_check
 
 import pytest
 
@@ -36,7 +36,7 @@ def t2_doc():
         "channel": ["CHANCHAN"],
         "code": DocumentCode.OK,
         "tag": ["TAGGERT"],
-        "meta": [{}],
+        "meta": [{"tier": 2, "code": DocumentCode.OK}],
         "body": [{"foo": "bar"}],
     }
     return doc
@@ -111,3 +111,10 @@ def test_pickle(view: T2DocView | SnapView | T3DocView):
 def test_frozen(view: T2DocView | SnapView | T3DocView):
     with pytest.raises(ValueError, match="is read only"):
         view.id = 1
+
+class Foo(TypedDict):
+    foo: str
+
+def test_get_payload(t2_view: T2DocView):
+    assert t2_view.get_payload() == {"foo": "bar"}
+    assert t2_view.get_payload(Foo) == {"foo": "bar"}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -118,3 +118,5 @@ class Foo(TypedDict):
 def test_get_payload(t2_view: T2DocView):
     assert t2_view.get_payload() == {"foo": "bar"}
     assert t2_view.get_payload(Foo) == {"foo": "bar"}
+    with pytest.raises(ValueError, match="No content available"):
+        t2_view.get_payload(code=DocumentCode.T2_FAILED_DEPENDENCY, raise_exc=True)


### PR DESCRIPTION
- Loosen UBson UnionType, replacing dict with Mapping. This allows units to return instances of TypedDict.
- Allow overloads of T2DocView.get_payload() to allow return type inference. No actual type check is performed behind the scenes, however.