### PR TITLE
Allow dynamically registered units in AuxUnitRegister

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-interface"
-version = "0.10.4.post2"
+version = "0.10.5a0"
 description = "Base classes for the Ampel analysis platform"
 authors = ["Valery Brinnel"]
 maintainers = ["Jakob van Santen <jakob.van.santen@desy.de>"]


### PR DESCRIPTION
- Use class definition from `_dyn` if possible
- Allow calling post_init even without config