### PR TITLE
Optionally disable Exception catch and locals print

### DIFF
--- a/ampel/cli/main.py
+++ b/ampel/cli/main.py
@@ -116,9 +116,9 @@ def main() -> str | int | None:
 	except KeyboardInterrupt:
 		console.print("\n[red bold]Interrupted (Ctrl-C)[/]\n")
 		return 130 # conventional exit code for SIGINT
-	except BaseException:
-		console.print_exception(show_locals=True)
-		return 1
+	# except BaseException:
+	# 	console.print_exception(show_locals=True)
+	# 	return 1
 
 	return 0
 

--- a/ampel/cli/main.py
+++ b/ampel/cli/main.py
@@ -110,15 +110,27 @@ def main() -> str | int | None:
 		for k, v in vars(args).items():
 			print(f"  {k}: {v}")
 
+	if ('-no-print-locals' in unknown_args) or args.__getattribute__("no_print_locals"):
+		show_locals = False
+	else:
+		show_locals = True
+
+	if ('-no-catch' in unknown_args) or args.__getattribute__("no_catch"):
+		raise_exc = True
+	else:
+		raise_exc = False
+
 	console = Console(force_terminal=True, color_system="truecolor")
 	try:
 		cli_op.run(vars(args), unknown_args, sub_op)
 	except KeyboardInterrupt:
 		console.print("\n[red bold]Interrupted (Ctrl-C)[/]\n")
 		return 130 # conventional exit code for SIGINT
-	# except BaseException:
-	# 	console.print_exception(show_locals=True)
-	# 	return 1
+	except BaseException:
+		if raise_exc:
+			raise
+		console.print_exception(show_locals=show_locals)
+		return 1
 
 	return 0
 

--- a/ampel/cli/main.py
+++ b/ampel/cli/main.py
@@ -10,8 +10,8 @@
 import importlib
 import importlib.metadata
 import os
-import sys
 import signal
+import sys
 from random import random
 
 from rich.console import Console
@@ -110,12 +110,12 @@ def main() -> str | int | None:
 		for k, v in vars(args).items():
 			print(f"  {k}: {v}")
 
-	if ('-no-print-locals' in unknown_args) or args.__getattribute__("no_print_locals"):
+	if ('-no-print-locals' in unknown_args) or (hasattr(args, "no_print_locals") and args.no_print_locals):
 		show_locals = False
 	else:
 		show_locals = True
 
-	if ('-no-catch' in unknown_args) or args.__getattribute__("no_catch"):
+	if ('-no-catch' in unknown_args) or (hasattr(args, "no_catch") and args.no_catch):
 		raise_exc = True
 	else:
 		raise_exc = False


### PR DESCRIPTION
If an exception occurs during a CLI command, it is caught and the process exits with return code 1. This prevents IDEs from directly referencing the part of the code that raised the exception, enter debug mode at that place, etc. 
This adds two flags to the CLI without changing the current default behavior:
* `-no-catch`: disable the catching of Exceptions completely and let the code fail 
* `-no-print-locals`: Avoid including local variables in the traceback stack for readability.
